### PR TITLE
37 exclude stories not relevant for chromatic

### DIFF
--- a/.github/workflows/chromatic.yaml
+++ b/.github/workflows/chromatic.yaml
@@ -3,7 +3,7 @@ name: "Chromatic"
 
 # Event for the workflow
 on:
-  push:
+  pull_request:
     branches:
       - main
 

--- a/.github/workflows/chromatic.yaml
+++ b/.github/workflows/chromatic.yaml
@@ -6,6 +6,8 @@ on:
   pull_request:
     branches:
       - main
+    paths:
+      - "packages/ui/**"
 
 # Concurrency settings
 concurrency:
@@ -39,3 +41,4 @@ jobs:
         with:
           # 👇 Chromatic projectToken, refer to the manage page to obtain it.
           projectToken: ${{ secrets.CHROMATIC_PROJECT_TOKEN }}
+          workingDir: packages/ui

--- a/packages/ui/src/components/ui/accordion.stories.tsx
+++ b/packages/ui/src/components/ui/accordion.stories.tsx
@@ -102,6 +102,9 @@ export const SingleAccordion: Story = {
 
 // You can add a new story to demonstrate the usage of controls
 export const WithControls: Story = {
+  parameters: {
+    chromatic: { disableSnapshot: true },
+  },
   args: {
     type: "single",
     collapsible: true,

--- a/packages/ui/src/components/ui/alert.stories.tsx
+++ b/packages/ui/src/components/ui/alert.stories.tsx
@@ -56,9 +56,10 @@ export const Showcase = () => {
   );
 };
 
-export const Interactive: Story = {
+export const WithControls: Story = {
   parameters: {
     controls: { disable: false },
+    chromatic: { disableSnapshot: true },
   },
   args: {
     variant: "default",

--- a/packages/ui/src/components/ui/button.stories.tsx
+++ b/packages/ui/src/components/ui/button.stories.tsx
@@ -125,13 +125,14 @@ export const Disabled: Story = {
   },
 };
 
-export const Interactive: Story = {
+export const WithControls: Story = {
   parameters: {
     controls: { disable: false },
+    chromatic: { disableSnapshot: true },
   },
   args: {
     children: "Button",
-    variant: "fill", // Set default value for variant here
+    variant: "fill", // Set default   value for variant here
     intent: "default", // Set default value for intent here
     size: "md", // Set default value for size here
   },

--- a/packages/ui/src/components/ui/calendar.stories.tsx
+++ b/packages/ui/src/components/ui/calendar.stories.tsx
@@ -14,6 +14,9 @@ export default meta;
 type Story = StoryObj<typeof Calendar>;
 
 export const WithControls: Story = {
+  parameters: {
+    chromatic: { disableSnapshot: true },
+  },
   args: {
     weekStartsOn: 1,
     mode: "single",

--- a/packages/ui/src/components/ui/carousel.stories.tsx
+++ b/packages/ui/src/components/ui/carousel.stories.tsx
@@ -21,6 +21,9 @@ type Story = StoryObj<typeof Carousel>;
 
 // TODO - expose controls API to storybook
 export const WithControls: Story = {
+  parameters: {
+    chromatic: { disableSnapshot: true },
+  },
   render: (args) => (
     <Carousel className="w-full max-w-xs" {...args}>
       <CarouselContent>

--- a/packages/ui/src/components/ui/chevron-toggle.stories.tsx
+++ b/packages/ui/src/components/ui/chevron-toggle.stories.tsx
@@ -26,6 +26,9 @@ export const Showcase: Story = {
 };
 
 export const WithControls: Story = {
+  parameters: {
+    chromatic: { disableSnapshot: true },
+  },
   args: {
     isOpen: false,
     alt: false,

--- a/packages/ui/src/components/ui/collapsible.stories.tsx
+++ b/packages/ui/src/components/ui/collapsible.stories.tsx
@@ -30,6 +30,9 @@ export default meta;
 type Story = StoryObj<typeof Collapsible>;
 
 export const Interactive: Story = {
+  parameters: {
+    chromatic: { disableSnapshot: true },
+  },
   render: () => {
     const [isOpen, setIsOpen] = useState(false);
 

--- a/packages/ui/src/components/ui/dialog.stories.tsx
+++ b/packages/ui/src/components/ui/dialog.stories.tsx
@@ -32,6 +32,9 @@ export default meta;
 type Story = StoryObj<typeof Dialog>;
 
 export const Interactive: Story = {
+  parameters: {
+    chromatic: { disableSnapshot: true },
+  },
   render: () => (
     <Dialog>
       <DialogTrigger asChild>

--- a/packages/ui/src/components/ui/form.stories.tsx
+++ b/packages/ui/src/components/ui/form.stories.tsx
@@ -36,6 +36,9 @@ const formSchema = z.object({
 });
 
 export const Interactive: Story = {
+  parameters: {
+    chromatic: { disableSnapshot: true },
+  },
   render: () => {
     const form = useForm<z.infer<typeof formSchema>>({
       resolver: zodResolver(formSchema),

--- a/packages/ui/src/components/ui/icon-button.stories.tsx
+++ b/packages/ui/src/components/ui/icon-button.stories.tsx
@@ -129,16 +129,17 @@ export const Active: Story = {
   },
 };
 
-export const Interactive: Story = {
+export const WithControls: Story = {
+  parameters: {
+    controls: { disable: false },
+    chromatic: { disableSnapshot: true },
+  },
   render: (args) => {
     return (
       <IconButton {...args}>
         <Plus />
       </IconButton>
     );
-  },
-  parameters: {
-    controls: { disable: false },
   },
   args: {
     variant: "fill", // Set default value for variant here

--- a/packages/ui/src/components/ui/input.stories.tsx
+++ b/packages/ui/src/components/ui/input.stories.tsx
@@ -123,7 +123,11 @@ export const DisabledState: Story = {
   ),
 };
 
-export const Interactive: Story = {
+export const WithControls: Story = {
+  parameters: {
+    controls: { disable: false },
+    chromatic: { disableSnapshot: true },
+  },
   args: {
     placeholder: "Interactive input",
     type: "text",
@@ -148,9 +152,6 @@ export const Interactive: Story = {
         type: "boolean",
       },
     },
-  },
-  parameters: {
-    controls: { disable: false },
   },
   render: (args) => <Input {...args} />,
 };

--- a/packages/ui/src/components/ui/popover.stories.tsx
+++ b/packages/ui/src/components/ui/popover.stories.tsx
@@ -80,13 +80,14 @@ export const WithCustomContent: Story = {
 };
 
 export const WithControls: Story = {
+  parameters: {
+    controls: { disable: false },
+    chromatic: { disableSnapshot: true },
+  },
   args: {
     defaultOpen: false,
     open: false,
     modal: false,
-  },
-  parameters: {
-    controls: { disable: false },
   },
   argTypes: {
     open: {

--- a/packages/ui/src/components/ui/radio-group.stories.tsx
+++ b/packages/ui/src/components/ui/radio-group.stories.tsx
@@ -148,6 +148,7 @@ export const Disabled: Story = {
 export const WithControls: Story = {
   parameters: {
     controls: { disable: false },
+    chromatic: { disableSnapshot: true },
   },
   args: {
     defaultValue: "option1",

--- a/packages/ui/src/components/ui/select.stories.tsx
+++ b/packages/ui/src/components/ui/select.stories.tsx
@@ -168,6 +168,7 @@ export const WithGroups: Story = {
 export const WithControls: Story = {
   parameters: {
     controls: { disable: false },
+    chromatic: { disableSnapshot: true },
   },
   args: {
     value: "apple",

--- a/packages/ui/src/components/ui/separator.stories.tsx
+++ b/packages/ui/src/components/ui/separator.stories.tsx
@@ -58,13 +58,14 @@ export const Decorative: Story = {
 };
 
 export const WithControls: Story = {
+  parameters: {
+    chromatic: { disableSnapshot: true },
+    controls: { disable: false },
+  },
   args: {
     decorative: false,
     orientation: "horizontal",
     className: "h-initial",
-  },
-  parameters: {
-    controls: { disable: false },
   },
   argTypes: {
     orientation: {

--- a/packages/ui/src/components/ui/star-rating.stories.tsx
+++ b/packages/ui/src/components/ui/star-rating.stories.tsx
@@ -10,6 +10,9 @@ const meta: Meta<typeof StarRating> = {
   parameters: {
     controls: { hideNoControlsWarning: true, disable: true },
   },
+  args: {
+    onRatingChange: fn(),
+  },
   argTypes: {
     rating: { control: { type: "range", min: 0, max: 5, step: 1 } },
     totalStars: { control: { type: "number", min: 1, max: 10 } },
@@ -49,12 +52,13 @@ export const FullRating: Story = {
 };
 
 export const Interactive: Story = {
+  parameters: {
+    controls: { disable: false },
+    chromatic: { disableSnapshot: true },
+  },
   args: {
     rating: 1,
     totalStars: 5,
-  },
-  parameters: {
-    controls: { disable: false },
   },
   argTypes: {
     onRatingChange: {
@@ -82,12 +86,13 @@ export const Interactive: Story = {
   },
 };
 export const WithControls: Story = {
+  parameters: {
+    controls: { disable: false },
+    chromatic: { disableSnapshot: true },
+  },
   args: {
     rating: 1,
     totalStars: 5,
-  },
-  parameters: {
-    controls: { disable: false },
   },
   argTypes: {
     onRatingChange: {

--- a/packages/ui/src/components/ui/status-chip.stories.tsx
+++ b/packages/ui/src/components/ui/status-chip.stories.tsx
@@ -37,6 +37,10 @@ export const WithoutChildren: Story = {
 };
 
 export const WithControls: Story = {
+  parameters: {
+    controls: { disable: false },
+    chromatic: { disableSnapshot: true },
+  },
   args: {
     intent: "neutral",
     children: "Neutral Text",
@@ -49,9 +53,6 @@ export const WithControls: Story = {
     children: {
       control: "text",
     },
-  },
-  parameters: {
-    controls: { disable: false },
   },
   render: (args) => {
     return <StatusChip {...args} />;

--- a/packages/ui/src/components/ui/tabs.stories.tsx
+++ b/packages/ui/src/components/ui/tabs.stories.tsx
@@ -147,6 +147,7 @@ export const Disabled: Story = {
 export const WithControls: Story = {
   parameters: {
     controls: { disable: false },
+    chromatic: { disableSnapshot: true },
   },
   args: {
     defaultValue: "tab1",

--- a/packages/ui/src/components/ui/text.stories.tsx
+++ b/packages/ui/src/components/ui/text.stories.tsx
@@ -80,6 +80,7 @@ export const KeywordText: Story = {
 export const HeadingWithControls: Story = {
   parameters: {
     controls: { disable: false },
+    chromatic: { disableSnapshot: true },
   },
   args: {
     size: "md",
@@ -112,6 +113,7 @@ export const HeadingWithControls: Story = {
 export const BodyWithControls: Story = {
   parameters: {
     controls: { disable: false },
+    chromatic: { disableSnapshot: true },
   },
   args: {
     size: "md",
@@ -144,6 +146,7 @@ export const BodyWithControls: Story = {
 export const KeywordWithControls: Story = {
   parameters: {
     controls: { disable: false },
+    chromatic: { disableSnapshot: true },
   },
   args: {
     size: "md",

--- a/packages/ui/src/components/ui/textarea.stories.tsx
+++ b/packages/ui/src/components/ui/textarea.stories.tsx
@@ -65,6 +65,7 @@ export const Disabled: Story = {
 export const WithControls: Story = {
   parameters: {
     controls: { disable: false },
+    chromatic: { disableSnapshot: true },
   },
   args: {
     placeholder: "I'm some placeholder text",

--- a/packages/ui/src/components/ui/toaster.stories.tsx
+++ b/packages/ui/src/components/ui/toaster.stories.tsx
@@ -16,6 +16,9 @@ export default meta;
 type Story = StoryObj<typeof Toaster>;
 
 export const Interactive: Story = {
+  parameters: {
+    chromatic: { disableSnapshot: true },
+  },
   render: () => {
     const { toast } = useToast();
     return (
@@ -83,6 +86,7 @@ export const WithAction: Story = {
 export const WithControls: Story = {
   parameters: {
     controls: { disable: false },
+    chromatic: { disableSnapshot: true },
   },
   args: {
     title: "Toast with Action",

--- a/packages/ui/src/components/ui/toggle-group.stories.tsx
+++ b/packages/ui/src/components/ui/toggle-group.stories.tsx
@@ -156,6 +156,7 @@ export const SingleSelect: Story = {
 export const WithControls: Story = {
   parameters: {
     controls: { disable: false },
+    chromatic: { disableSnapshot: true },
   },
   args: {
     size: "sm",

--- a/packages/ui/src/components/ui/toggle.stories.tsx
+++ b/packages/ui/src/components/ui/toggle.stories.tsx
@@ -98,6 +98,7 @@ export const Disabled: Story = {
 export const WithControls: Story = {
   parameters: {
     controls: { disable: false },
+    chromatic: { disableSnapshot: true },
   },
   args: {
     variant: "and-or",


### PR DESCRIPTION
closes #37 

1. Excludes chromatic snapshot from "Interactive" and "WithControls" stories
2.  Run in CI only on pull requests against main
3. Only run the chromatic action when changes are present in the ui package