### PR TITLE
adds workflow to run pnpm format

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -17,4 +17,4 @@ jobs:
       - name: Install dependencies
         run: pnpm install
       - name: Run format
-        run: pnpm format --check
+        run: pnpm format:check

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -17,4 +17,4 @@ jobs:
       - name: Install dependencies
         run: pnpm install
       - name: Run format
-        run: pnpm format
+        run: pnpm format --check

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,0 +1,20 @@
+name: Format
+on: push
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Use Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: "18"
+      - name: Install pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 8
+      - name: Install dependencies
+        run: pnpm install
+      - name: Run format
+        run: pnpm format

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,21 +1,20 @@
 name: Lint
-on: 
-  push
-  
+on: push
+
 jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-        - uses: actions/checkout@v3
-        - name: Use Node.js
-          uses: actions/setup-node@v3
-          with:
-            node-version: "18"
-        - name: Install pnpm
-          uses: pnpm/action-setup@v2
-          with:
-            version: 8
-        - name: Install dependencies
-          run: pnpm install
-        - name: Run lint
-          run: pnpm lint
+      - uses: actions/checkout@v3
+      - name: Use Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: "18"
+      - name: Install pnpm
+        uses: pnpm/action-setup@v2
+        with:
+          version: 8
+      - name: Install dependencies
+        run: pnpm install
+      - name: Run lint
+        run: pnpm lint

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "dev": "turbo dev",
     "dev:crm": "turbo dev --filter=@repo/copilot-crm -- --port 3001",
     "dev:portal": "turbo dev --filter=@repo/client-portal -- --port 3000",
-    "format:check": "prettier --check --list-different \"**/*.{ts,tsx,md}\"",
+    "format:check": "prettier --list-different \"**/*.{ts,tsx,md}\"",
     "format": "prettier --write \"**/*.{ts,tsx,md}\"",
     "lint": "turbo lint",
     "test": "vitest",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "dev": "turbo dev",
     "dev:crm": "turbo dev --filter=@repo/copilot-crm -- --port 3001",
     "dev:portal": "turbo dev --filter=@repo/client-portal -- --port 3000",
-    "format:check": "prettier --check \"**/*.{ts,tsx,md}\"",
+    "format:check": "prettier --check --list-different \"**/*.{ts,tsx,md}\"",
     "format": "prettier --write \"**/*.{ts,tsx,md}\"",
     "lint": "turbo lint",
     "test": "vitest",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "dev": "turbo dev",
     "dev:crm": "turbo dev --filter=@repo/copilot-crm -- --port 3001",
     "dev:portal": "turbo dev --filter=@repo/client-portal -- --port 3000",
+    "format:check": "prettier --check \"**/*.{ts,tsx,md}\"",
     "format": "prettier --write \"**/*.{ts,tsx,md}\"",
     "lint": "turbo lint",
     "test": "vitest",

--- a/packages/mocks/businessInfo.ts
+++ b/packages/mocks/businessInfo.ts
@@ -15,7 +15,10 @@ export const BUSINESS_INFO = {
   socialMedia: [
     { name: "Facebook", url: "https://www.facebook.com/madisonhandyman" },
     { name: "Instagram", url: "https://www.instagram.com/madisonhandyman" },
-    { name: "LinkedIn", url: "https://www.linkedin.com/company/madisonhandyman" },
+    {
+      name: "LinkedIn",
+      url: "https://www.linkedin.com/company/madisonhandyman",
+    },
     { name: "Twitter", url: "https://www.twitter.com/madisonhandyman" },
   ],
 };

--- a/packages/mocks/handlers.ts
+++ b/packages/mocks/handlers.ts
@@ -6,7 +6,7 @@ import { PROPERTIES } from "./property";
 import { PAYMENT_INFO } from "./payment-info";
 import { MOCK_DOCUMENTS } from "./documents";
 import { MOCK_ASSETS } from "./assets.mock";
-import { BUSINESS_INFO } from './businessInfo';
+import { BUSINESS_INFO } from "./businessInfo";
 
 export const handlers = [
   // get all users


### PR DESCRIPTION
closes #39

we now run prettier with the --list-different flag in the CI.  We use "--list-different" instead of just "--check" so we actually get the output of the specific files where a prettier change was needed.

This will catch any case where a format change wasn't picked up by the linter or our local editors for whatever reason.

For example these two files 

<img width="1105" alt="Screen Shot 2024-10-20 at 9 32 49 PM" src="https://github.com/user-attachments/assets/d6b04a84-2d25-446e-9748-b3b94a9e889b">






